### PR TITLE
Handle the case where spliceCommandLength == 0x0fff.

### DIFF
--- a/__tests__/scte35.spec.ts
+++ b/__tests__/scte35.spec.ts
@@ -18,6 +18,8 @@
 
 import { expect } from "chai";
 import { SCTE35 } from "../src/scte35";
+import { ISpliceInsertEvent, ISpliceTime, SpliceCommandType } from "../src/ISCTE35";
+import * as descriptors from "../src/descriptors";
 
 describe("SCTE35", () => {
     const scte35: SCTE35 = new SCTE35();
@@ -48,7 +50,6 @@ describe("SCTE35", () => {
                 expect(spliceInfo.descriptors.length).to.eq(2);
             }
         });
-
         /*tslint:disable*/
         //TODO: write unit tests for additional property checking on these base64 string
         // it("should parse from another base64", () => {
@@ -92,6 +93,42 @@ describe("SCTE35", () => {
             expect((scte35 as any).parseBase64(message)).to.equal(
                 "We are looking for contributors that want to help improve this library, want to help?"
             );
+        });
+    });
+    describe("Legacy splice_command_length==0x0fff", () => {
+        it("should parse time_signal", () => {
+            const base64 =
+		"/DA6AAAAAAAAAP///wb+GIZQCAAkAiJDVUVJAAv9L3//AAFeMHAMDkRJU0M2NzQ5NjNfOTk4MAEBsXXbjg";
+            const spliceInfo = scte35.parseFromB64(base64);
+            expect(spliceInfo.spliceCommandType).to.equal(SpliceCommandType.TIME_SIGNAL);
+	    const spliceCommand = spliceInfo.spliceCommand as ISpliceTime;
+	    expect(spliceCommand.pts).to.equal(411455496);
+
+            expect(spliceInfo.descriptors).to.not.equal(undefined);
+            expect(spliceInfo.descriptors?.length).to.equal(1);
+	    if (spliceInfo.descriptors) {
+            	expect(spliceInfo.descriptors[0].indentifier).to.equal("CUEI");
+		const spliceDescriptor=(spliceInfo.descriptors[0] as descriptors.ISegmentationDescriptor);
+            	expect(spliceDescriptor.segmentationDuration).to.eq(22950000);
+            	expect(spliceDescriptor.segmentationTypeId).to.eq(48);
+	    }
+        });
+
+        it("should parse splice_insert", () => {
+            const base64 =
+		"/DAxAAAAAAAAAP///wUAhcJPf+/+zBS4Ln4AUmXAAAAAAAAMAQpDVUVJAJ8wNDgq0FP4ig";
+            const spliceInfo = scte35.parseFromB64(base64);
+            expect(spliceInfo.spliceCommandType).to.equal(SpliceCommandType.SPLICE_INSERT);
+	    const spliceCommand = spliceInfo.spliceCommand as ISpliceInsertEvent;
+	    expect(spliceCommand.spliceEventId).to.equal(8766031);
+	    expect(spliceCommand.spliceTime?.pts).to.equal(3423909934);
+	    expect(spliceCommand.breakDuration?.duration).to.equal(5400000);
+
+            expect(spliceInfo.descriptors).to.not.equal(undefined);
+            expect(spliceInfo.descriptors?.length).to.equal(1);
+	    if (spliceInfo.descriptors) {
+            	expect(spliceInfo.descriptors[0].indentifier).to.equal("CUEI");
+	    }
         });
     });
 });

--- a/src/scte35.ts
+++ b/src/scte35.ts
@@ -238,6 +238,43 @@ export class SCTE35 implements ISCTE35 {
 
         sis.spliceCommandType = view.getUint8(offset++);
 
+        // Workaround for spliceCommandLength =0x0fff, which is a legacy fallback 
+        if (sis.spliceCommandLength === 0x0fff) {
+            if (sis.spliceCommandType === SpliceCommandType.TIME_SIGNAL) {
+                let time_specified_flag = view.getUint8(offset) & 0x80;
+                sis.spliceCommandLength = time_specified_flag ? 5 : 1;
+            } else if (sis.spliceCommandType === SpliceCommandType.SPLICE_NULL) {
+                sis.spliceCommandLength = 0;
+            } else if (sis.spliceCommandType === SpliceCommandType.SPLICE_INSERT) {
+                let io = offset; // Our cursor parsing the splice_insert
+                io += 4;
+                let splice_event_cancel_indicator = view.getUint8(io++) & 0x80;
+                if (!splice_event_cancel_indicator) {
+                    let flags = view.getUint8(io++);
+                    // Decode flags
+                    let splice_immediate_flag = flags & 0x10;
+                    let duration_flag = flags & 0x20;
+                    let program_splice_flag = flags & 0x40;
+                    let out_of_network_indicator = flags & 0x80;
+                    if (program_splice_flag && !splice_immediate_flag) {
+                        io += 5;
+                    }
+                    if (!program_splice_flag) {
+                        let component_count = view.getUint8(io++);
+                        io += component_count;
+                        io += splice_immediate_flag ? 0 : component_count * 5;
+                    }
+                    if (duration_flag) {
+                        io += 5;
+                    }
+                    io += 4;
+                    sis.spliceCommandLength = io - offset;
+                }
+            } else {
+		// SPLICE_SCHEDULE, PRIVEATE_COMMAND not support without length
+                console.error(`scte35-js Unspecified length not supported in this context`);
+            }
+        }
         if (sis.spliceCommandType !== SpliceCommandType.SPLICE_NULL) {
             const splice = new DataView(bytes.buffer, offset, sis.spliceCommandLength);
             if (sis.spliceCommandType === SpliceCommandType.SPLICE_SCHEDULE) {


### PR DESCRIPTION
The standard says
"The value of 0xFFF provides backwards compatibility and shall be ignored by downstream equipment." So we need to derive the length by parsing the structure, which is a pain but possible.