### PR TITLE
Supporting private command

### DIFF
--- a/__tests__/scte35.spec.ts
+++ b/__tests__/scte35.spec.ts
@@ -18,6 +18,7 @@
 
 import { expect } from "chai";
 import { SCTE35 } from "../src/scte35";
+import { ISplicePrivate } from "../src/ISCTE35";
 
 describe("SCTE35", () => {
     const scte35: SCTE35 = new SCTE35();
@@ -47,6 +48,16 @@ describe("SCTE35", () => {
             if (spliceInfo.descriptors) {
                 expect(spliceInfo.descriptors.length).to.eq(2);
             }
+        });
+
+        it("should parse scte-35 with private_command()", () => {
+            const base64 = "/DA5AAAAAAAAAP/wKP8AAAABZXdvZ0ltMWxjM05oWjJVaU9pQWlZV1JrVjJsa1oyVjBJZ3A5AAAUDmUl";
+            const spliceInfo = scte35.parseFromB64(base64);
+            const splicePrivate = spliceInfo.spliceCommand as ISplicePrivate;
+            expect(splicePrivate.identifier).to.equal(1);
+            expect(String.fromCharCode(...new Uint8Array(splicePrivate.rawData))).to.equal(
+                "ewogIm1lc3NhZ2UiOiAiYWRkV2lkZ2V0Igp9"
+            );
         });
 
         /*tslint:disable*/

--- a/src/scte35.ts
+++ b/src/scte35.ts
@@ -25,6 +25,7 @@ import {
     ISpliceTime,
     ISpliceInfoSection,
     ISCTE35,
+    ISplicePrivate,
 } from "./ISCTE35";
 import * as descriptors from "./descriptors";
 import * as util from "./util";
@@ -196,6 +197,20 @@ export class SCTE35 implements ISCTE35 {
         return spliceTime;
     }
 
+    /*
+     * 9.7.6. private_command()
+     */
+    private privateCommand(view: DataView): ISplicePrivate {
+        const splicePrivate = {} as ISplicePrivate;
+        const byte = view.getUint32(0);
+        let payload = new Uint8Array(view.buffer, view.byteOffset + 4, view.byteLength - 4);
+        splicePrivate.identifier = byte;
+        if (splicePrivate.identifier) {
+            splicePrivate.rawData = payload;
+        }
+        return splicePrivate;
+    }
+
     // Table 5 splice_info_section
     private parseSCTE35Data(bytes: Uint8Array): ISpliceInfoSection {
         const sis: ISpliceInfoSection = {};
@@ -247,7 +262,7 @@ export class SCTE35 implements ISCTE35 {
             } else if (sis.spliceCommandType === SpliceCommandType.TIME_SIGNAL) {
                 sis.spliceCommand = this.timeSignal(splice);
             } else if (sis.spliceCommandType === SpliceCommandType.PRIVATE_COMMAND) {
-                console.error(`scte35-js command_type private_command not supported.`);
+                sis.spliceCommand = this.privateCommand(splice);
             }
         }
         offset += sis.spliceCommandLength;


### PR DESCRIPTION
After following the SCTE35 standard we implemented the private command

<img width="777" alt="image" src="https://github.com/Comcast/scte35-js/assets/31115265/4e8f3bc3-be83-49e0-b4d9-f96322b43832">

https://wagtail-prod-storage.s3.amazonaws.com/documents/SCTE_35_2022b.pdf