### PR TITLE
chore: fixed publish flow

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@ test
 ui
 docs
 jsdoc
+coverage
 .nyc_output
 .vscode
 .jshintrc
@@ -10,4 +11,3 @@ jsdoc
 .prettierignore
 .gitignore
 __tests__
-

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Angular demo in `ui/` has its own `package.json` and release flow. Root depe
 
 ## Release
 
-The npm package publishes the compiled files from `build/`, so make releases from a clean branch after validating the root project:
+The npm package publishes a small allowlisted set of files: compiled output from `build/`, generated type declarations, CLI scripts, package metadata, license/notice files, the README, and assets used by the README. Make releases from a clean branch after validating the root project:
 
 ```bash
 npm install
@@ -36,6 +36,8 @@ npm run build
 npm run docs
 npm audit
 ```
+
+Commit the version bump and regenerated `jsdoc/` output before merging the release branch. The publish step does not regenerate docs.
 
 Update the package version with `npm version patch`, `npm version minor`, or `npm version major`, then inspect the package before publishing:
 
@@ -50,7 +52,7 @@ When the dry-run looks right, publish from the root directory:
 npm publish
 ```
 
-The publish lifecycle runs `prepublishOnly` first, which executes `npm run build && npm run docs`. After publishing, `postpublish` runs `npm run clean`, removing the generated `build/` directory from the working tree.
+The publish lifecycle runs `prepublishOnly` first, which executes `npm run build`. After publishing, `postpublish` runs `npm run clean`, removing the generated `build/` directory from the working tree.
 
 ## Demo
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
     "description": "",
     "main": "build/scte35.js",
     "types": "build/scte35.d.ts",
+    "files": [
+        "NOTICE",
+        "assets",
+        "build/**/*.d.ts",
+        "build/**/*.js",
+        "scripts"
+    ],
     "directories": {
         "lib": "lib",
         "test": "test"
@@ -20,7 +27,7 @@
         "test": "tsx node_modules/mocha/bin/mocha.js --watch-extensions ts,tsx __tests__/*.spec.ts",
         "build": "npm run clean && tsc",
         "postpublish": "npm run clean",
-        "prepublishOnly": "npm run build && npm run docs"
+        "prepublishOnly": "npm run build"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
- Updated the npm publish flow so prepublishOnly only runs npm run build; docs are no longer regenerated during npm publish.
- Kept TypeDoc generation as an explicit release-prep step via npm run docs, with README guidance to commit regenerated jsdoc/ before merging the release branch.
- Added a files allowlist to package.json so the published package only includes runtime/package assets: compiled JS, generated .d.ts files, CLI scripts, README, license/notice files, package metadata, and README image assets.
- Excluded coverage/ from npm packaging via .npmignore.
- Updated README release instructions to match the new publish flow and package contents.
- Verified npm publish --dry-run now produces a 15-file package with no coverage/, jsdoc/, source files, source maps, lint configs, or TypeScript configs.